### PR TITLE
詳細写真をモーダルで拡大表示

### DIFF
--- a/app/assets/stylesheets/posts/show.css
+++ b/app/assets/stylesheets/posts/show.css
@@ -161,3 +161,27 @@
   text-align: center;
   color: #aa998a;
 }
+
+#grayDisplay {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  max-width: 100% !important;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+}
+
+#grayDisplay img {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: auto;
+  max-width: 90%;
+  max-height: 90%;
+  height: 90%;
+  object-fit: contain;
+}

--- a/app/javascript/modal.js
+++ b/app/javascript/modal.js
@@ -1,0 +1,10 @@
+$(document).on("click", ".show-img", function () {
+  $("#grayDisplay").html($(this).prop("outerHTML"));
+  $("#grayDisplay").fadeIn(200);
+  return false;
+});
+
+$(document).on("click", "#grayDisplay", function () {
+  $("#grayDisplay").fadeOut(200);
+  return false;
+});

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -14,6 +14,7 @@ require("../icon_hover");
 require("../preview");
 require("../jquery.raty");
 require("../menu");
+require("../modal");
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -27,6 +27,7 @@
           <%= "#" + tag&.name %>
         <% end %>
       </div>
+      <div id="grayDisplay"></div>
 
 
       <div class="show-sub-contents">


### PR DESCRIPTION
jqueryで詳細写真をクリックすると拡大して確認できるモーダルを出現させる実装を行った。

![詳細モーダル](https://user-images.githubusercontent.com/88925285/149882475-695b4616-5d52-4af6-beeb-6a1354dc7fee.gif)
